### PR TITLE
PlainYearMonth.with() - issue#143(spec 9.3.13) 

### DIFF
--- a/src/builtins/core/date.rs
+++ b/src/builtins/core/date.rs
@@ -124,41 +124,6 @@ macro_rules! impl_with_fallback_method {
         }
     };
 }
-/*
-impl PartialDate {
-    /// Merges a PartialDate with a PlainYearMonth, filling missing values.
-    pub(crate) fn with_fallback_year_month(&self, fallback: &PlainYearMonth) -> TemporalResult<Self> {
-        let era = if let Some(era) = self.era {
-            Some(era)
-        } else {
-            fallback.era()?.map(|e| {
-                TinyAsciiStr::<19>::try_from_utf8(e.as_bytes())
-                    .map_err(|e| TemporalError::general(format!("{e}")))
-            }).transpose()?
-        };
-
-        let era_year = self.era_year.or(fallback.era_year()?);
-
-        // Resolve month and monthCode together
-        let (resolved_month, resolved_month_code) = match (self.month, self.month_code) {
-            (Some(month), Some(month_code)) => (Some(month), Some(month_code)), // Both provided
-            (Some(month), None) => (Some(month), Some(month_to_month_code(month)?)), // Infer month_code
-            (None, Some(month_code)) => (Some(ascii_four_to_integer(month_code)?), Some(month_code)), // Infer month
-            (None, None) => (Some(fallback.month()?), Some(fallback.month_code()?)), // Keep existing values
-        };
-
-        Ok(Self {
-            year: self.year.or(Some(fallback.iso_year())),
-            month: resolved_month,
-            month_code: resolved_month_code,
-            day: Some(1), // Use day=1 since YearMonth doesn't store a specific day
-            era,
-            era_year,
-            calendar: fallback.calendar().clone(),
-        })
-    }
-} // TODO Preferably have this integrated into the 'impl_with_fallback_method' macro
-*/
 /// The native Rust implementation of `Temporal.PlainDate`.
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -928,6 +893,19 @@ mod tests {
             TinyAsciiStr::<4>::from_str("M11").unwrap()
         );
         assert_eq!(with_day.day().unwrap(), 17);
+        /*
+        // ArithmeticOverflow for PlainDate, the test currently fails
+        let partial = PartialDate {
+            month: Some(13),
+            ..Default::default()
+        };
+        // Constrained behavior
+        let with_overflow_constrain = base.with(partial, Some(ArithmeticOverflow::Constrain)).unwrap(); // This should produce a "M13" error
+        assert_eq!(with_overflow_constrain.month(), Ok(12));
+
+        // Reject behavior
+        // ...
+        */
     }
 
     // test262/test/built-ins/Temporal/Calendar/prototype/month/argument-string-invalid.js

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -250,7 +250,6 @@ impl FromStr for PlainYearMonth {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::partial;
@@ -268,11 +267,11 @@ mod tests {
             ..Default::default()
         };
 
-        let result = base.with(partial, None).unwrap();
-        assert_eq!(result.iso_year(), 2001); // year is changed
-        assert_eq!(result.iso_month(), 3); // month is not changed
+        let with_year = base.with(partial, None).unwrap();
+        assert_eq!(with_year.iso_year(), 2001); // year is changed
+        assert_eq!(with_year.iso_month(), 3); // month is not changed
         assert_eq!(
-            result.month_code().unwrap(),
+            with_year.month_code().unwrap(),
             TinyAsciiStr::<4>::from_str("M03").unwrap()
         ); // assert month code has been initialized correctly
 
@@ -281,11 +280,11 @@ mod tests {
             month: Some(2),
             ..Default::default()
         };
-        let result = base.with(partial, None).unwrap();
-        assert_eq!(result.iso_year(), 2025); // year is not changed
-        assert_eq!(result.iso_month(), 2); // month is changed
+        let with_month = base.with(partial, None).unwrap();
+        assert_eq!(with_month.iso_year(), 2025); // year is not changed
+        assert_eq!(with_month.iso_month(), 2); // month is changed
         assert_eq!(
-            result.month_code().unwrap(),
+            with_month.month_code().unwrap(),
             TinyAsciiStr::<4>::from_str("M02").unwrap()
         ); // assert month code has changed as well as month
 
@@ -294,12 +293,22 @@ mod tests {
             month_code: Some(tinystr!(4,"M05")), // change month to May (5)
             ..Default::default()
         };
-        let result = base.with(partial, None).unwrap();
-        assert_eq!(result.iso_year(), 2025); // year is not changed
+        let with_month_code = base.with(partial, None).unwrap();
+        assert_eq!(with_month_code.iso_year(), 2025); // year is not changed
         assert_eq!(
-            result.month_code().unwrap(),
+            with_month_code.month_code().unwrap(),
             TinyAsciiStr::<4>::from_str("M05").unwrap()
         ); // assert month code has changed
-        assert_eq!(result.iso_month(), 5); // month is changed as well 
+        assert_eq!(with_month_code.iso_month(), 5); // month is changed as well 
+
+        // Day
+        let partial = PartialDate {
+            day: Some(15),
+            ..Default::default()
+        };
+        let with_day = base.with(partial, None).unwrap();
+        assert_eq!(with_day.iso_year(), 2025); // year is not changed
+        assert_eq!(with_day.iso_month(), 3); // month is not changed
+        assert_eq!(with_day.iso.day, 15); // day is changed
     }
 }

--- a/src/builtins/core/year_month.rs
+++ b/src/builtins/core/year_month.rs
@@ -137,17 +137,24 @@ impl PlainYearMonth {
         self.calendar.identifier()
     }
 
+    /// Returns the calendar day value.
+    pub fn day(&self) -> TemporalResult<u8> {
+        self.calendar.day(&self.iso)
+    }
+
     pub fn with(
         &self,
-        partial_year_month: PlainYearMonth,
+        partial: PartialDate,
         overflow: Option<ArithmeticOverflow>,
     ) -> TemporalResult<Self> {
         // 1. Let yearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
         // 3. If ? IsPartialTemporalObject(temporalYearMonthLike) is false, throw a TypeError exception.
+        if partial.is_empty() {
+            return Err(TemporalError::r#type().with_message("A PartialDate must have a field."));
+        };
         // 4. Let calendar be yearMonth.[[Calendar]].
         // 5. Let fields be ISODateToFields(calendar, yearMonth.[[ISODate]], year-month).
-        let partial_fields = PartialDate::try_from_year_month(&partial_year_month)?;
         // 6. Let partialYearMonth be ? PrepareCalendarFields(calendar, temporalYearMonthLike, « year, month, month-code », « », partial).
         // 7. Set fields to CalendarMergeFields(calendar, fields, partialYearMonth).
         // 8. Let resolvedOptions be ? GetOptionsObject(options).
@@ -155,7 +162,7 @@ impl PlainYearMonth {
         // 10. Let isoDate be ? CalendarYearMonthFromFields(calendar, fields, overflow).
         // 11. Return ! CreateTemporalYearMonth(isoDate, calendar).
         self.calendar.year_month_from_partial(
-            &partial_fields,
+            &partial.with_fallback_year_month(self)?,
             overflow.unwrap_or(ArithmeticOverflow::Reject),
         )
     }
@@ -240,5 +247,59 @@ impl FromStr for PlainYearMonth {
             calendar,
             ArithmeticOverflow::Reject,
         )
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::partial;
+    use tinystr::tinystr;
+
+    use super::*;
+
+    #[test]
+    fn test_plain_year_month() {
+        let base = PlainYearMonth::new_with_overflow(2025, 3, None, Calendar::default(), ArithmeticOverflow::Reject).unwrap();
+
+        // Year
+        let partial = PartialDate {
+            year: Some(2001),
+            ..Default::default()
+        };
+
+        let result = base.with(partial, None).unwrap();
+        assert_eq!(result.iso_year(), 2001); // year is changed
+        assert_eq!(result.iso_month(), 3); // month is not changed
+        assert_eq!(
+            result.month_code().unwrap(),
+            TinyAsciiStr::<4>::from_str("M03").unwrap()
+        ); // assert month code has been initialized correctly
+
+        // Month
+        let partial = PartialDate {
+            month: Some(2),
+            ..Default::default()
+        };
+        let result = base.with(partial, None).unwrap();
+        assert_eq!(result.iso_year(), 2025); // year is not changed
+        assert_eq!(result.iso_month(), 2); // month is changed
+        assert_eq!(
+            result.month_code().unwrap(),
+            TinyAsciiStr::<4>::from_str("M02").unwrap()
+        ); // assert month code has changed as well as month
+
+        // Month Code
+        let partial = PartialDate {
+            month_code: Some(tinystr!(4,"M05")), // change month to May (5)
+            ..Default::default()
+        };
+        let result = base.with(partial, None).unwrap();
+        assert_eq!(result.iso_year(), 2025); // year is not changed
+        assert_eq!(
+            result.month_code().unwrap(),
+            TinyAsciiStr::<4>::from_str("M05").unwrap()
+        ); // assert month code has changed
+        assert_eq!(result.iso_month(), 5); // month is changed as well 
     }
 }


### PR DESCRIPTION
Better with() implementation conforming with spec
Unit test: test_plain_year_month_with() inside year_month.rs
Issue observed in YearMonth & PlainDate with ArithmeticOverflow not handling Constrain on month_code when changing month, see comments in test_plain_year_month_with() & basic_date_with tests.